### PR TITLE
Change the aesthetics of Project Info at Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Rust and people may not even know because they never see a `libpython`,
 
 ## Project Info
 
-:house: The official home of the `PyOxidizer` project is
-https://github.com/indygreg/PyOxidizer.
+:house: The official home of the `PyOxidizer` project is [indygreg/PyOxidizer](https://github.com/indygreg/PyOxidizer)
+.
 
 :notebook_with_decorative_cover: Documentation (generated from the `docs/` directory) is available
-at https://pyoxidizer.readthedocs.io/en/latest/index.html.
+[on ReadTheDocs.io](https://pyoxidizer.readthedocs.io/en/latest/index.html).
 
 :speech_balloon: The [pyoxidizer-users](https://groups.google.com/forum/#!forum/pyoxidizer-users)
 mailing list is a forum for users to discuss all things PyOxidizer.


### PR DESCRIPTION
This list looks better if the URLs would not break the lines. 
## Currently
![image](https://user-images.githubusercontent.com/9844978/111596342-5b048380-87cd-11eb-8e9b-3e388a39916e.png)

## This PR
![image](https://user-images.githubusercontent.com/9844978/111596546-92733000-87cd-11eb-85d8-040e746b4d89.png)

